### PR TITLE
Update suite for re-qualification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ tools/jacoco/jacocoagent.jar filter=lfs diff=lfs merge=lfs -text
 tools/jacoco/jacocoant.jar filter=lfs diff=lfs merge=lfs -text
 tools/jacoco/jacococli.jar filter=lfs diff=lfs merge=lfs -text
 tools/apalache-0.57.0.jar filter=lfs diff=lfs merge=lfs -text
+tools/2026.04.27.203507/tla2tools.jar filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ tools/apalache-0.28.0.jar filter=lfs diff=lfs merge=lfs -text
 tools/jacoco/jacocoagent.jar filter=lfs diff=lfs merge=lfs -text
 tools/jacoco/jacocoant.jar filter=lfs diff=lfs merge=lfs -text
 tools/jacoco/jacococli.jar filter=lfs diff=lfs merge=lfs -text
+tools/apalache-0.57.0.jar filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
             bwrap --ro-bind / / --unshare-user --unshare-ipc echo "bwrap successfully configured"
       - name: Run testgen
         run: |
-            python -m testgen -o reports/ -s -e --html -x explanation.yaml -w $(nproc) --tlc-jar tools/1.8.0/tla2tools.jar
+            python -m testgen -o reports/ -s -e --html -x explanation.yaml -w $(nproc) --tlc-jar tools/1.8.0/tla2tools.jar --reduced-workers
       - name: Upload report to https://dl.tlapl.us/validation-test-suite for easy access.
         if: always()
         uses: burnett01/rsync-deployments@7.1.0

--- a/explanation.yaml
+++ b/explanation.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/explanation.yaml
+++ b/explanation.yaml
@@ -775,3 +775,19 @@ explanations:
         include zero, and returns an error otherwise. BagCopiesIn returns zero, because there no such
         value in the bag, therefore TLC reports error. Apalache always returns some sequence and doesn't
         crash in such situations
+
+    - desc: {'case_feature': 'Unchanged', 'plug_feature': 'BagEmptyBag', 'check_deadlock': True}
+      result:
+        tlc: violation
+        ref: crash
+      explanation: >-
+        TLC model check results are correct. Apalache cannot infer the type of the compound
+        expression and reports a type error.
+
+    - desc: {'case_feature': 'Unchanged', 'plug_feature': 'BagEmptyBag', 'check_deadlock': False}
+      result:
+        tlc: violation
+        ref: crash
+      explanation: >-
+        TLC model check results are correct. Apalache cannot infer the type of the compound
+        expression and reports a type error.

--- a/explanation.yaml
+++ b/explanation.yaml
@@ -406,20 +406,6 @@ explanations:
         same action and Apalache complains about spurious manual assignment, because it
         is unable to detect that the second usage is just no-op
 
-    - desc: {'case_feature': 'Lambda', 'plug_feature': 'Boxed', 'check_deadlock': False}
-      result:
-        tlc: crash
-        ref: violation
-      explanation: >-
-        TLC does not support boxed operator in LAMBDA expressions and reports an error
-
-    - desc: {'case_feature': 'Lambda', 'plug_feature': 'Boxed', 'check_deadlock': True}
-      result:
-        tlc: crash
-        ref: violation
-      explanation: >-
-        TLC does not support boxed operator in LAMBDA expressions and reports an error
-
     - desc: {'case_feature': 'Enabled', 'plug_feature': 'Prime', 'check_deadlock': False}
       result:
         tlc: violation
@@ -435,70 +421,6 @@ explanations:
       explanation: >-
         TLC model check results are correct. Apalache does not support ENABLED operator
         and if used with prime operator it is irreducible to equivalent ENABLED-free form
-
-    - desc: {'case_feature': 'InstanceNamedWith', 'plug_feature': 'InstanceWith', 'check_deadlock': False}
-      result:
-        tlc: success
-        ref: crash
-      explanation: >-
-        TLC model check results are correct. Apalache has a bug, which prevents it from
-        type checking the specification
-
-    - desc: {'case_feature': 'InstanceNamedWith', 'plug_feature': 'InstanceWith', 'check_deadlock': True}
-      result:
-        tlc: success
-        ref: crash
-      explanation: >-
-        TLC model check results are correct. Apalache has a bug, which prevents it from
-        type checking the specification
-
-    - desc: {'case_feature': 'InstanceNamedWith', 'plug_feature': 'Instance', 'check_deadlock': False}
-      result:
-        tlc: success
-        ref: crash
-      explanation: >-
-        TLC model check results are correct. Apalache has a bug, which prevents it from
-        type checking the specification
-
-    - desc: {'case_feature': 'InstanceNamedWith', 'plug_feature': 'Instance', 'check_deadlock': True}
-      result:
-        tlc: success
-        ref: crash
-      explanation: >-
-        TLC model check results are correct. Apalache has a bug, which prevents it from
-        type checking the specification
-
-    - desc: {'case_feature': 'InstanceNamed', 'plug_feature': 'InstanceWith', 'check_deadlock': False}
-      result:
-        tlc: success
-        ref: crash
-      explanation: >-
-        TLC model check results are correct. Apalache has a bug, which prevents it from
-        type checking the specification
-
-    - desc: {'case_feature': 'InstanceNamed', 'plug_feature': 'InstanceWith', 'check_deadlock': True}
-      result:
-        tlc: success
-        ref: crash
-      explanation: >-
-        TLC model check results are correct. Apalache has a bug, which prevents it from
-        type checking the specification
-
-    - desc: {'case_feature': 'InstanceNamed', 'plug_feature': 'Instance', 'check_deadlock': False}
-      result:
-        tlc: success
-        ref: crash
-      explanation: >-
-        TLC model check results are correct. Apalache has a bug, which prevents it from
-        type checking the specification
-
-    - desc: {'case_feature': 'InstanceNamed', 'plug_feature': 'Instance', 'check_deadlock': True}
-      result:
-        tlc: success
-        ref: crash
-      explanation: >-
-        TLC model check results are correct. Apalache has a bug, which prevents it from
-        type checking the specification
 
     - desc: {'case_feature': 'ConstantRank1', 'plug_feature': 'ConstantRank1', 'check_deadlock': False}
       result:
@@ -521,64 +443,16 @@ explanations:
         tlc: crash
         ref: violation
       explanation: >-
-        There is a known TLC bug (https://github.com/tlaplus/tlaplus/issues/720), which causes TLC to report
-        an error, when a parameterized operator is used to specify a property
+        There is a known TLC bug (https://github.com/tlaplus/tlaplus/issues/1389), which causes TLC to report
+        an error, when a recursive operator is used to specify a property
 
     - desc: {'case_feature': 'Def1Recursive', 'plug_feature': 'Boxed', 'check_deadlock': True}
       result:
         tlc: crash
         ref: violation
       explanation: >-
-        There is a known TLC bug (https://github.com/tlaplus/tlaplus/issues/720), which causes TLC to report
-        an error, when a parameterized operator is used to specify a property
-
-    - desc: {'case_feature': 'Def2', 'plug_feature': 'Boxed', 'check_deadlock': False}
-      result:
-        tlc: crash
-        ref: violation
-      explanation: >-
-        There is a known TLC bug (https://github.com/tlaplus/tlaplus/issues/720), which causes TLC to report
-        an error, when a parameterized operator is used to specify a property
-
-    - desc: {'case_feature': 'Def2', 'plug_feature': 'Boxed', 'check_deadlock': True}
-      result:
-        tlc: crash
-        ref: violation
-      explanation: >-
-        There is a known TLC bug (https://github.com/tlaplus/tlaplus/issues/720), which causes TLC to report
-        an error, when a parameterized operator is used to specify a property
-
-    - desc: {'case_feature': 'Def1', 'plug_feature': 'Boxed', 'check_deadlock': False}
-      result:
-        tlc: crash
-        ref: violation
-      explanation: >-
-        There is a known TLC bug (https://github.com/tlaplus/tlaplus/issues/720), which causes TLC to report
-        an error, when a parameterized operator is used to specify a property
-
-    - desc: {'case_feature': 'Def1', 'plug_feature': 'Boxed', 'check_deadlock': True}
-      result:
-        tlc: crash
-        ref: violation
-      explanation: >-
-        There is a known TLC bug (https://github.com/tlaplus/tlaplus/issues/720), which causes TLC to report
-        an error, when a parameterized operator is used to specify a property
-
-    - desc: {'case_feature': 'LetDef0', 'plug_feature': 'Boxed', 'check_deadlock': False, 'reduction_strategy': {'feature_case': 'LET definitions are reduced to global definitions'}}
-      result:
-        tlc: crash
-        ref: violation
-      explanation: >-
-        TLC expects temporal properties to be specified directly without using operators or LET expression.
-        Otherwise it reports an error
-
-    - desc: {'case_feature': 'LetDef0', 'plug_feature': 'Boxed', 'check_deadlock': True, 'reduction_strategy': {'feature_case': 'LET definitions are reduced to global definitions'}}
-      result:
-        tlc: crash
-        ref: violation
-      explanation: >-
-        TLC expects temporal properties to be specified directly without using operators or LET expression.
-        Otherwise it reports an error
+        There is a known TLC bug (https://github.com/tlaplus/tlaplus/issues/1389), which causes TLC to report
+        an error, when a recursive operator is used to specify a property
 
     - desc: {'case_feature': 'NumPlus', 'plug_feature': 'NumMaxInt', 'check_deadlock': False}
       result:

--- a/symmetry.md
+++ b/symmetry.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,10 +37,11 @@ All test cases use the same TLA+ specification file `SymmetrySpec.tla`
 
 Test cases are created for every pairwise combination of `SYMMETRY` and
 
-* `CHECK_DEADLOCK` (`TRUE`/`FALSE`)
+* Variants of specifying symmetry set permutations:`Permutations(U)` or`Permutations(U) \union Permutations(V)`
+* `CHECK_DEADLOCK` (`TRUE` or `FALSE`)
 * `VIEW` (present or not)
-* `INVARIANT` (present or not)
-* `PROPERTY` (present or not)
+* `INVARIANT` (correct, violating or absent)
+* `PROPERTY` (correct, violating or absent)
 
 Reference configuration uses the same TLA+ specification and the same CFG file without `SYMMETRY`.
 

--- a/testgen/SymmetrySpec.tla
+++ b/testgen/SymmetrySpec.tla
@@ -66,10 +66,13 @@ Spec == Init /\ [][Next]_vars
 
 ----
 
-Inv == (left \union right) = Messages
-Prop == [] Inv
+InvPos == (left \union right) = Messages
+InvNeg == right \subseteq left
+PropPos == [](~ENABLED Next => (iteration = Iterations /\ left = {}))
+PropNeg == [][left' \subseteq left]_left
 
-MessagesSymm == Permutations(Messages)
+MessagesSymm1 == Permutations(Messages)
+MessagesSymm2 == Permutations({M0, M1}) \union Permutations({M2, M3})
 IterationsDef == 2
 ViewDef == <<left, right, iteration>>
 

--- a/testgen/__main__.py
+++ b/testgen/__main__.py
@@ -172,6 +172,9 @@ def main():
                         help='Enable debug output')
 
     # Test case filtering
+    parser.add_argument("--reduced-workers", dest="reduced_workers",
+                        action='store_true', default=False,
+                        help="Reduce number of workers variants to 2")
     parser.add_argument("-n", "--no-symmetry", dest='no_symmetry',
                         action='store_true', default=False,
                         help="Sandboxing: do not generate SYMMETRY cases")
@@ -210,6 +213,8 @@ def main():
             jacoco_jar_override = args.jacoco_jar)
 
     if args.spec:
+        select_workers_options(args.reduced_workers)
+
         if args.filter_any_side:
             filter = any_side(*args.filter_any_side)
         elif args.filter_any_side_exact:

--- a/testgen/__main__.py
+++ b/testgen/__main__.py
@@ -167,6 +167,9 @@ def main():
                         help="Number of workers (normally number of physical cores)", metavar="WORKERS", default = 4, type = int)
     parser.add_argument("-x", "--explanation-db", dest="explanation_db", default=None,
                         help="YAML file with tests failure explanations", metavar="FILE")
+    parser.add_argument("--report-unused-explanations", dest="report_unused_explanations",
+                        action='store_true', default=False,
+                        help="Report unused explanations")
     parser.add_argument('-d', '--debug',
                         action='store_true', dest="debug", default=False,
                         help='Enable debug output')
@@ -237,6 +240,8 @@ def main():
             workers = args.workers,
             explanation_db = explanation_db,
             force = args.force)
+        if args.explanation_db and args.report_unused_explanations:
+            explanation_db.report_unused_keys()
 
     if args.coverage and jacoco_jar:
         collect_coverage(

--- a/testgen/__main__.py
+++ b/testgen/__main__.py
@@ -251,6 +251,9 @@ def main():
     if args.html:
         generate_html(output_dir = args.output_dir)
 
+    if explanation_db.had_errors():
+        exit(1)
+
 if __name__ == '__main__':
     try:
         main()

--- a/testgen/__main__.py
+++ b/testgen/__main__.py
@@ -213,8 +213,10 @@ def main():
             jacoco_jar_override = args.jacoco_jar)
 
     if args.spec:
-        select_workers_options(args.reduced_workers)
-
+        # `--reduced-workers` only affects the specification stage.
+        # The chosen workers_options are persisted in specification.json
+        # so later stages can recover the value without the CLI switch.
+        set_workers_options(compute_workers_options(args.reduced_workers))
         if args.filter_any_side:
             filter = any_side(*args.filter_any_side)
         elif args.filter_any_side_exact:

--- a/testgen/ast.py
+++ b/testgen/ast.py
@@ -646,7 +646,7 @@ class StrSet:
 
     def ir(self):
         return {
-            "type": "Str",
+            "type": "Set(Str)",
             "kind": "ValEx",
             "value": {
               "kind": "TlaStrSet"

--- a/testgen/ast.py
+++ b/testgen/ast.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from enum import Enum, auto, unique
-import itertools
 import os
 import json
 import logging
@@ -554,6 +553,7 @@ standard_table = {
     'BagOfAll' : 'BagOfAll',
     'BagCardinality' : 'BagCardinality',
     'CopiesIn' : 'CopiesIn',
+    'Assert' : 'Assert',
 }
 
 # Strip module (bang) prefix

--- a/testgen/explanation.py
+++ b/testgen/explanation.py
@@ -50,6 +50,7 @@ class ExplanationDB:
         self.db = {}
         self.db_file = db_file
         self.used_keys = set()
+        self.error_found = False
 
         if not db_file:
             return
@@ -59,7 +60,8 @@ class ExplanationDB:
             key = make_key(i['desc'])
             if key in self.db:
                 logging.error(f'ExplanationDB: {i["desc"]} has duplicates in `{db_file}`')
-                exit(1)
+                self.error_found = True
+                continue
             self.db[key] = Explanation(
                 desc = i['desc'],
                 tlc = i['result']['tlc'],
@@ -73,7 +75,8 @@ class ExplanationDB:
             self.used_keys.add(key)
             if e.tlc != tlc or e.ref != ref:
                 logging.error(f'ExplanationDB: {e.desc} results ({e.tlc}, {e.ref}) are inconsistent with actual results ({tlc}, {ref}) `{self.db_file}`')
-                exit(1)
+                self.error_found = True
+                return None
         return e
 
     def report_unused_keys(self):
@@ -81,3 +84,6 @@ class ExplanationDB:
         if unused_keys:
             keys = '\n'.join([f'  {key}' for key in sorted(unused_keys)])
             logging.warning(f'ExplanationDB: {len(unused_keys)} keys are unused in `{self.db_file}`:\n{keys}')
+
+    def had_errors(self):
+        return self.error_found

--- a/testgen/explanation.py
+++ b/testgen/explanation.py
@@ -49,6 +49,7 @@ class ExplanationDB:
     def __init__(self, db_file):
         self.db = {}
         self.db_file = db_file
+        self.used_keys = set()
 
         if not db_file:
             return
@@ -69,7 +70,14 @@ class ExplanationDB:
         key = make_key(desc)
         e = self.db.get(key)
         if e:
+            self.used_keys.add(key)
             if e.tlc != tlc or e.ref != ref:
                 logging.error(f'ExplanationDB: {e.desc} results ({e.tlc}, {e.ref}) are inconsistent with actual results ({tlc}, {ref}) `{self.db_file}`')
                 exit(1)
         return e
+
+    def report_unused_keys(self):
+        unused_keys = self.db.keys() - self.used_keys
+        if unused_keys:
+            keys = '\n'.join([f'  {key}' for key in unused_keys])
+            logging.warning(f'ExplanationDB: {len(unused_keys)} keys are unused in `{self.db_file}`:\n{keys}')

--- a/testgen/explanation.py
+++ b/testgen/explanation.py
@@ -79,5 +79,5 @@ class ExplanationDB:
     def report_unused_keys(self):
         unused_keys = self.db.keys() - self.used_keys
         if unused_keys:
-            keys = '\n'.join([f'  {key}' for key in unused_keys])
+            keys = '\n'.join([f'  {key}' for key in sorted(unused_keys)])
             logging.warning(f'ExplanationDB: {len(unused_keys)} keys are unused in `{self.db_file}`:\n{keys}')

--- a/testgen/feature.py
+++ b/testgen/feature.py
@@ -4211,8 +4211,7 @@ class TlcAssertF(Feature):
             "'IF cond THEN TRUE ELSE \"assert crash\" = FALSE'.")
 
     def kind(self):
-        # Assert may only be used in actions thus it accepts
-        # only action, state and const expressions
+        # Assert may only accept action, state and const expressions.
         return [Kind.Action, Kind.State, Kind.Const]
 
     def type(self):

--- a/testgen/feature.py
+++ b/testgen/feature.py
@@ -4201,6 +4201,84 @@ class TlcEvalF(Feature):
         expr = type.sample()
         return self.teval_reduced(expr)
 
+class TlcAssertF(Feature):
+    def can_be_reduced(self):
+        return True
+
+    def reduction_strategy(self):
+        return (
+            "Assert(cond, msg) is reduced to specially crafted TLC crash: "
+            "'IF cond THEN TRUE ELSE \"assert crash\" = FALSE'.")
+
+    def kind(self):
+        # Assert may only be used in actions thus it accepts
+        # only action, state and const expressions
+        return [Kind.Action, Kind.State, Kind.Const]
+
+    def type(self):
+        return bool_t
+
+    def assert_op(self, cond, msg):
+        self.add_extends_standard('TLC')
+        ref = Def1Ref('Assert')
+        ref.type = Def1T(bool_t, bool_t, rest_args = [str_t])
+        r = Def1App(ref, cond, msg)
+        r.type = bool_t
+        r.kind = cond.kind
+        return r
+
+    # If input is not a bool, then build FALSE value
+    # TLC halts on a FALSE condition - and that's what we want to test
+    def construct_value(self, hole):
+        if hole.type.match(bool_t):
+            return hole
+        r = BinOp(BinOpId.Ne, hole, hole)
+        r.type = bool_t
+        r.kind = hole.kind
+        return r
+
+    def make_msg(self):
+        msg = Str("assertion_message")
+        msg.type = str_t
+        msg.kind = Kind.Const
+        return msg
+
+    def make_crash(self, expr):
+        crash_expr = eq(Str("assert crash"), Bool(False))
+        return IfThenElse(expr, Bool(True), crash_expr)
+
+    def case(self, hole):
+        cond = self.construct_value(hole)
+        expr = self.assert_op(cond, self.make_msg())
+        return self.testmodel_template(next = self.next_y(expr))
+
+    def case_tlc_reduced(self, hole):
+        expr = self.make_crash(hole)
+        args, kw = self.testmodel_template(next = self.next_y(expr))
+        return TlcModel(*args, **kw)
+
+    def plug(self, type):
+        if Kind.Action not in self.kinds:
+            return SkipReason.KindMismatch
+        if not type.match(bool_t):
+            return SkipReason.TypeMismatch
+        # Setting cond to False because we need to check that TLC finds
+        # assertion violations if they are there
+        cond = Bool(False)
+        cond.type = bool_t
+        cond.kind = Kind.Const
+        return self.assert_op(cond, self.make_msg())
+
+    def plug_tlc_reduced(self, type):
+        if Kind.Action not in self.kinds:
+            return SkipReason.KindMismatch
+        if not type.match(bool_t):
+            return SkipReason.TypeMismatch
+        cond = self.make_crash(Bool(False))
+        cond.type = bool_t
+        cond.kind = Kind.Const
+        return cond
+
 class BagBagToSetF(Feature):
     def kind(self):
         return simple_kinds

--- a/testgen/html_report.py
+++ b/testgen/html_report.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 import os
 import json
 from jinja2 import Environment, FileSystemLoader
-from .spec import workers_options, WORKERS_1
+from .spec import get_workers_options, load_spec, WORKERS_1
 from .testcasedefs import *
 
 def get_template_path():
@@ -90,10 +90,11 @@ class IndexSkippedRefs:
 
 def find_workers(tc):
     options = tc['tlc']['cmd_options']
-    for w in workers_options:
+    workers = get_workers_options()
+    for w in workers:
         if w in options:
             return w
-    assert False, f'Intersection of `{workers_options}` and command options `{options}` is empty'
+    assert False, f'Intersection of `{workers}` and command options `{options}` is empty'
     return None
 
 def build_index(spec):
@@ -278,13 +279,13 @@ def generate_failed_html(env, html_dir, spec, results, toc):
 
 def generate_index_html(env, html_dir, index, results, toc):
     index_refs = {}
-    for w in workers_options:
+    for w in get_workers_options():
         index_refs[w] = generate_index_workers_html(env, html_dir, index, w, results, toc)
 
     return index_refs
 
 def generate_feature_toc(env, html_dir, index_refs, features, toc):
-    for w in workers_options:
+    for w in get_workers_options():
         template_file = "test-feature.html"
         template = env.get_template(template_file)
         content = template.render(
@@ -317,7 +318,7 @@ def generate_main_html(env, html_dir, spec, results, toc):
 
         template_file = "test-toc.html"
         template = env.get_template(template_file)
-        content = template.render(workers = workers_options, statistics = statistics, toc = toc)
+        content = template.render(workers = get_workers_options(), statistics = statistics, toc = toc)
 
         html_file = template_file
         save_file(os.path.join(html_dir, html_file), content)
@@ -325,7 +326,7 @@ def generate_main_html(env, html_dir, spec, results, toc):
 def get_index_toc_html(env):
         template_file = "test-side-toc.html"
         template = env.get_template(template_file)
-        return template.render(workers = workers_options
+        return template.render(workers = get_workers_options()
 )
 
 def add_model(models, tc, model, result):
@@ -347,9 +348,9 @@ def generate_html_report(
     html_dir = os.path.join(output_dir, 'html')
     os.makedirs(html_dir, exist_ok = True)
 
-    # Load test specification
-    with open(spec_file) as spec_h:
-        spec = json.load(spec_h)
+    # Load test specification. As a side effect, this restores the global
+    # workers_options from the value persisted in spec_file.
+    spec = load_spec(spec_file)
 
     # Load test results
     with open(exec_report_file) as report_h:

--- a/testgen/html_report.py
+++ b/testgen/html_report.py
@@ -93,7 +93,7 @@ def find_workers(tc):
     for w in workers_options:
         if w in options:
             return w
-    assert False, 'Non-reachable code'
+    assert False, f'Intersection of `{workers_options}` and command options `{options}` is empty'
     return None
 
 def build_index(spec):

--- a/testgen/html_report.py
+++ b/testgen/html_report.py
@@ -15,6 +15,7 @@
 
 import os
 import json
+import logging
 from jinja2 import Environment, FileSystemLoader
 from .spec import get_workers_options, load_spec, WORKERS_1
 from .testcasedefs import *
@@ -267,7 +268,9 @@ def generate_failed_html(env, html_dir, spec, results, toc):
             continue
 
         desc = tc['desc']
-        assert 'case_feature' in desc, "Do not expect failed test cases in SYMMETRY"
+        if 'case_feature' not in desc:
+            logging.error(f"Unexpected test case failure:\n{json.dumps(tc, indent = 2)}")
+            exit(1)
 
         # There must be no failed testcase for all workers except WORKERS_1
         assert find_workers(tc) == WORKERS_1, f"Unexpected failed test cases for '{find_workers(tc)}'"

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -168,45 +168,18 @@ def tlc_args(spec_dir, exec_dir, desc, coverage):
         # From SANY
         4800, # EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY
         4801, # INSTANCED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY
-        # Disabled because it is not a critical warning
-        # 4802, # RECORD_CONSTRUCTOR_FIELD_NAME_CLASH
-        # Disabled because PlusCal is out of scope for qualification
-        # 4803, # PLUSCAL_ALGORITHM_AND_TRANSLATION_CHANGED_SINCE_LAST_TRANSLATION
-        # 4804, # PLUSCAL_ALGORITHM_CHANGED_SINCE_LAST_TRANSLATION
-        # 4805, # PLUSCAL_TRANSLATION_CHANGED_SINCE_LAST_TRANSLATION
         # From TLC
         1000, # GENERAL
         2142, # TLC_WRONG_RECORD_FIELD_NAME
         2141, # TLC_WRONG_TUPLE_FIELD_NAME
-        # Disabled because it can be intentional
-        # 2259, # TLC_CONFIG_NO_FAIRNESS_BUT_LIVE_PROPERTY
-        # Three warnings are commented out because they are liveness-related and out of scope for qualification
-        # 2257, # ?? TLC_CONFIG_NO_SPEC_BUT_PROPERTY
-        # 2279, # TLC_FEATURE_UNSUPPORTED_LIVENESS_SYMMETRY
-        # 2284, # ?? TLC_FEATURE_LIVENESS_CONSTRAINTS
-        # Disabled because it may be intentional
-        # 2255, # ?? TLC_LIVE_FORMULA_STATE_LEVEL
-        # Disabled because it may be intentional
-        # 2258, # TLC_LIVE_FORMULA_AND_FAIRNESS_TAUTOLOGY
-        # Disabled because it is not a critical warning
-        # 2149, # TLC_INVARIANT_CONSTANT_LEVEL
-        # Must be enabled in qualification scope
         2139, # TLC_COULD_NOT_DETERMINE_SUBSCRIPT
-        # Must be enabled in qualification scope
         2140, # TLC_SUBSCRIPT_CONTAIN_NO_STATE_VAR
         2400, # TLC_MODULE_VALUE_JAVA_METHOD_OVERRIDE_MISMATCH
         2402, # TLC_MODULE_VALUE_JAVA_METHOD_OVERRIDE_MODULE_MISMATCH
         2403, # TLC_MODULE_VALUE_JAVA_METHOD_OVERRIDE_IDENTIFIER_MISMATCH
-        # Must be enabled in qualification scope
         2143, # TLC_UNCHANGED_VARIABLE_CHANGED
         2144, # TLC_EXCEPT_APPLIED_TO_UNKNOWN_FIELD
-        # Not a critical warning
-        # 2300, # ?? TLC_SYMMETRY_SET_TOO_SMALL
         2156, # TLC_FEATURE_UNSUPPORTED
-        # Not a critical warning
-        # 2166, # ?? TLC_FP_VALUE_ALREADY_ON_DISK
-        # Not a critical warning
-        # 2126, # SYSTEM_CHECKPOINT_RECOVERY_CORRUP
     ]
 
     max_polynomial_index = 130

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -62,7 +62,7 @@ RESULT_ASSERT='assert'
 RESULT_CRASH='crash'
 
 tlc_default_jar = os.path.join('tools', '2026.04.27.203507', 'tla2tools.jar')
-apalache_default_jar = os.path.join('tools', 'apalache-0.28.0.jar')
+apalache_default_jar = os.path.join('tools', 'apalache-0.57.0.jar')
 jacoco_default_jar = os.path.join('tools', 'jacoco', 'jacocoagent.jar')
 
 tlc_jar = None

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -20,6 +20,7 @@ import random
 import subprocess
 import tempfile
 from .parallel import *
+from .spec import load_spec
 
 '''
 TLC Error Codes
@@ -419,10 +420,6 @@ def testcase_execution_report(report, explanation_db, execution_results):
     report['explained'] = explanation != None
     if explanation != None:
         report['explanation'] = explanation.explanation
-
-def load_spec(spec_file):
-    with open(spec_file, 'r') as h:
-        return json.load(h)
 
 def run_testcases_parallel(
         spec_dir,

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -16,6 +16,7 @@
 import logging
 import os
 import json
+import random
 import subprocess
 import tempfile
 from .parallel import *
@@ -56,9 +57,10 @@ RESULT_SUCCESS='success'
 RESULT_VIOLATION='violation'
 RESULT_DEADLOCK='deadlock'
 RESULT_ASSUMPTION='assumption'
+RESULT_ASSERT='assert'
 RESULT_CRASH='crash'
 
-tlc_default_jar = os.path.join('tools', '1.7.2', 'tla2tools.jar')
+tlc_default_jar = os.path.join('tools', '2026.04.27.203507', 'tla2tools.jar')
 apalache_default_jar = os.path.join('tools', 'apalache-0.28.0.jar')
 jacoco_default_jar = os.path.join('tools', 'jacoco', 'jacocoagent.jar')
 
@@ -161,13 +163,64 @@ def tlc_args(spec_dir, exec_dir, desc, coverage):
     else:
         jacoco = []
 
+    warnings_as_errors = [
+        # From SANY
+        4800, # EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY
+        4801, # INSTANCED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY
+        # Disabled because it is not a critical warning
+        # 4802, # RECORD_CONSTRUCTOR_FIELD_NAME_CLASH
+        # Disbaled because PlusCal is out of scope for qualification
+        # 4803, # PLUSCAL_ALGORITHM_AND_TRANSLATION_CHANGED_SINCE_LAST_TRANSLATION
+        # 4804, # PLUSCAL_ALGORITHM_CHANGED_SINCE_LAST_TRANSLATION
+        # 4805, # PLUSCAL_TRANSLATION_CHANGED_SINCE_LAST_TRANSLATION
+        # From TLC
+        1000, # GENERAL
+        2142, # TLC_WRONG_RECORD_FIELD_NAME
+        2141, # TLC_WRONG_TUPLE_FIELD_NAME
+        # Disabled because it can be intentional
+        # 2259, # TLC_CONFIG_NO_FAIRNESS_BUT_LIVE_PROPERTY
+        # Three warnings are commented out because they are liveness-related and out of scope for qualification
+        # 2257, # ?? TLC_CONFIG_NO_SPEC_BUT_PROPERTY
+        # 2279, # TLC_FEATURE_UNSUPPORTED_LIVENESS_SYMMETRY
+        # 2284, # ?? TLC_FEATURE_LIVENESS_CONSTRAINTS
+        # Disabled because it may be intentional
+        # 2255, # ?? TLC_LIVE_FORMULA_STATE_LEVEL
+        # Disabled because it may be intentional
+        # 2258, # TLC_LIVE_FORMULA_AND_FAIRNESS_TAUTOLOGY
+        # Disabled because it is not a critical warning
+        # 2149, # TLC_INVARIANT_CONSTANT_LEVEL
+        # Must be enabled in qualification scope
+        2139, # TLC_COULD_NOT_DETERMINE_SUBSCRIPT
+        # Must be enabled in qualification scope
+        2140, # TLC_SUBSCRIPT_CONTAIN_NO_STATE_VAR
+        2400, # TLC_MODULE_VALUE_JAVA_METHOD_OVERRIDE_MISMATCH
+        2402, # TLC_MODULE_VALUE_JAVA_METHOD_OVERRIDE_MODULE_MISMATCH
+        2403, # TLC_MODULE_VALUE_JAVA_METHOD_OVERRIDE_IDENTIFIER_MISMATCH
+        # Must be enabled in qualification scope
+        2143, # TLC_UNCHANGED_VARIABLE_CHANGED
+        2144, # TLC_EXCEPT_APPLIED_TO_UNKNOWN_FIELD
+        # Not a critical warning
+        # 2300, # ?? TLC_SYMMETRY_SET_TOO_SMALL
+        2156, # TLC_FEATURE_UNSUPPORTED
+        # Not a critical warning
+        # 2166, # ?? TLC_FP_VALUE_ALREADY_ON_DISK
+        # Not a critical warning
+        # 2126, # SYSTEM_CHECKPOINT_RECOVERY_CORRUP
+    ]
+
+    max_polynomial_index = 130
+    polynomial_index = random.randint(0, max_polynomial_index)
+
     # Compose cmd line
     return [
         'java', '-XX:+UseParallelGC',
     ] + jacoco + [
         '-cp', tlc_jar,
     ] + search_paths_opts + [
-        'tlc2.TLC', '-lncheck', 'final',
+        'tlc2.TLC',
+        '-fp', str(polynomial_index),
+        '-lncheck', 'final',
+        '-messagesAsErrors', ','.join(map(str, warnings_as_errors)),
         '-metadir', mk_tmp(desc)
     ] + desc['cmd_options'] + [
         '-config', os.path.join(spec_dir, desc['cfg']['file']),
@@ -187,17 +240,16 @@ async def run_tlc_internal(spec_dir, exec_dir, desc, coverage, is_anomalous, max
 
     (exec_desc, returncode, stdout) = result
 
-    # As of 1.7.2 TLC has no option to turn warnings into errors
-    # At the same time, all TLC warnings are actually avoidable and some
-    # of them really dangerous
-    if b'*** Warnings:' in stdout:
-        status = f'warning<{returncode}>'
-    elif returncode == 0:
+    assert b'*** Warnings:' not in stdout, f'Unexpected warnings in stdout: {stdout}'
+
+    if returncode == 0:
         status = RESULT_SUCCESS
     elif returncode == VIOLATION_DEADLOCK:
         status = RESULT_DEADLOCK
     elif returncode == VIOLATION_ASSUMPTION:
         status = RESULT_ASSUMPTION
+    elif returncode == VIOLATION_ASSERT:
+        status = RESULT_ASSERT
     elif returncode in tlc_violation_codes:
         status = RESULT_VIOLATION
     else:
@@ -329,6 +381,10 @@ def testcase_execution_report(report, explanation_db, execution_results):
 
         if tc_type == TestCaseType_RefApalache:
             if tlc == RESULT_ASSUMPTION and ref == RESULT_VIOLATION:
+                # Apalache treats ASSUME statements as invariants
+                verdict = 'Passed'
+            elif tlc == RESULT_ASSERT and ref in [RESULT_VIOLATION, RESULT_DEADLOCK, RESULT_SUCCESS]:
+                #
                 # Apalache treats ASSUME statements as invariants
                 verdict = 'Passed'
             elif tlc != ref or tlc not in [RESULT_SUCCESS, RESULT_VIOLATION, RESULT_DEADLOCK]:

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -286,9 +286,7 @@ async def run_apalache_internal(spec_dir, desc, max_concurrent_tasks=1):
 
     (exec_desc, returncode, stdout) = await run_process(*args, env = env, max_concurrent_tasks=max_concurrent_tasks)
 
-    if b'*** Warnings:' in stdout:
-        status = f'warning<{returncode}>'
-    elif returncode == 150:
+    if returncode == 150:
         status = 'parseerror'
     elif returncode == 120:
         status = 'typeerror'

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -387,7 +387,9 @@ def testcase_execution_report(report, explanation_db, execution_results):
 
         if tc_type == TestCaseType_RefApalache:
             if tlc == RESULT_ASSUMPTION and ref == RESULT_VIOLATION:
-                # Apalache treats ASSUME statements as invariants
+                # In equivalent Apalache test cases ASSUME statements are rewritten as
+                # invariants (see AssumeF.case_apalache). Therefore, we expect Apalache to
+                # report invariant violation, when TLC reports assumption violation.
                 verdict = 'Passed'
             elif tlc != ref or tlc not in [RESULT_SUCCESS, RESULT_VIOLATION, RESULT_DEADLOCK]:
                 verdict = 'Failed'

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -169,7 +169,7 @@ def tlc_args(spec_dir, exec_dir, desc, coverage):
         4801, # INSTANCED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY
         # Disabled because it is not a critical warning
         # 4802, # RECORD_CONSTRUCTOR_FIELD_NAME_CLASH
-        # Disbaled because PlusCal is out of scope for qualification
+        # Disabled because PlusCal is out of scope for qualification
         # 4803, # PLUSCAL_ALGORITHM_AND_TRANSLATION_CHANGED_SINCE_LAST_TRANSLATION
         # 4804, # PLUSCAL_ALGORITHM_CHANGED_SINCE_LAST_TRANSLATION
         # 4805, # PLUSCAL_TRANSLATION_CHANGED_SINCE_LAST_TRANSLATION
@@ -248,10 +248,18 @@ async def run_tlc_internal(spec_dir, exec_dir, desc, coverage, is_anomalous, max
         status = RESULT_DEADLOCK
     elif returncode == VIOLATION_ASSUMPTION:
         status = RESULT_ASSUMPTION
-    elif returncode == VIOLATION_ASSERT:
-        status = RESULT_ASSERT
     elif returncode in tlc_violation_codes:
         status = RESULT_VIOLATION
+    elif (
+            # Normal way to detect assertion violations
+            returncode == VIOLATION_ASSERT or
+            # If used inside function bodies and ENABLED, TLC reports a different error code
+            # so we analyze the output to detect assertion violations
+            b'The first argument of Assert evaluated to FALSE' in stdout or
+            # This is a special case for assertions: equivalent TLC test cases are expected to
+            # crash by comparing string "assert crash" with a boolean value.
+            b'Attempted to check equality of string "assert crash"' in stdout):
+        status = RESULT_ASSERT
     else:
         status = RESULT_CRASH
 
@@ -383,10 +391,6 @@ def testcase_execution_report(report, explanation_db, execution_results):
             if tlc == RESULT_ASSUMPTION and ref == RESULT_VIOLATION:
                 # Apalache treats ASSUME statements as invariants
                 verdict = 'Passed'
-            elif tlc == RESULT_ASSERT and ref in [RESULT_VIOLATION, RESULT_DEADLOCK, RESULT_SUCCESS]:
-                #
-                # Apalache treats ASSUME statements as invariants
-                verdict = 'Passed'
             elif tlc != ref or tlc not in [RESULT_SUCCESS, RESULT_VIOLATION, RESULT_DEADLOCK]:
                 verdict = 'Failed'
                 explanation = explanation_db.find_explanation(desc['desc'], tlc, ref)
@@ -394,6 +398,7 @@ def testcase_execution_report(report, explanation_db, execution_results):
                     logging.info(f'Unexplained results for: {report["desc"]}')
                     logging.info(f'\t{tlc} :: {ref}')
             else:
+                assert tlc == ref
                 verdict = 'Passed'
         elif tc_type == TestCaseType_RefTlc:
             if tlc != ref:
@@ -403,6 +408,7 @@ def testcase_execution_report(report, explanation_db, execution_results):
                     logging.info(f'Unexplained results for: {report["desc"]}')
                     logging.info(f'\t{tlc} :: {ref}')
             else:
+                assert tlc == ref
                 verdict = 'Passed'
 
     assert verdict

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -288,11 +288,10 @@ async def run_apalache_internal(spec_dir, desc, max_concurrent_tasks=1):
 
     if b'*** Warnings:' in stdout:
         status = f'warning<{returncode}>'
-    elif b'Error parsing file' in stdout:
-        status = f'parseerror<{returncode}>'
-    elif b'meow' in stdout:
-        # Type errors, which are not signalled with exit code
-        status = f'typeerror<{returncode}>'
+    elif returncode == 150:
+        status = 'parseerror'
+    elif returncode == 120:
+        status = 'typeerror'
     elif returncode == 0:
         status = RESULT_SUCCESS
     elif returncode == 12:

--- a/testgen/runner.py
+++ b/testgen/runner.py
@@ -241,8 +241,6 @@ async def run_tlc_internal(spec_dir, exec_dir, desc, coverage, is_anomalous, max
 
     (exec_desc, returncode, stdout) = result
 
-    assert b'*** Warnings:' not in stdout, f'Unexpected warnings in stdout: {stdout}'
-
     if returncode == 0:
         status = RESULT_SUCCESS
     elif returncode == VIOLATION_DEADLOCK:

--- a/testgen/spec.py
+++ b/testgen/spec.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,13 +28,20 @@ WORKERS_AUTO = 'auto'
 
 workers_options = None
 
-def select_workers_options(reduced : bool) -> None:
-    global workers_options
+def compute_workers_options(reduced : bool) -> list:
     if reduced:
         # To reduce number of test cases, we exclude WORKERS_AUTO
-        workers_options = [WORKERS_1, WORKERS_2]
+        return [WORKERS_1, WORKERS_2]
     else:
-        workers_options = [WORKERS_1, WORKERS_2, WORKERS_AUTO]
+        return [WORKERS_1, WORKERS_2, WORKERS_AUTO]
+
+def set_workers_options(opts : list) -> None:
+    global workers_options
+    workers_options = opts
+
+def get_workers_options() -> list:
+    assert workers_options is not None, "set_workers_options() must be called before get_workers_options()"
+    return workers_options
 
 @dataclass
 class FeatureId:
@@ -275,6 +282,19 @@ def render_testcases(cases, path):
 
 def render_spec(spec_dir, spec_file, feature_filter, symmetry, anomalous):
     cases = prepare_testcases(feature_filter, symmetry = symmetry, anomalous = anomalous)
-    report = render_testcases(cases, spec_dir)
+    testcases = render_testcases(cases, spec_dir)
+    spec = {
+        'workers_options' : get_workers_options(),
+        'testcases' : testcases,
+    }
     with open(spec_file, 'w') as h:
-        json.dump(report, h, indent = 2)
+        json.dump(spec, h, indent = 2)
+
+# Load specification from file. Returns the testcases dict and, as a side
+# effect, restores the global workers_options from the value persisted in
+# the spec file.
+def load_spec(spec_file):
+    with open(spec_file, 'r') as h:
+        data = json.load(h)
+    set_workers_options(data['workers_options'])
+    return data['testcases']

--- a/testgen/spec.py
+++ b/testgen/spec.py
@@ -26,8 +26,15 @@ WORKERS_1 = '1'
 WORKERS_2 = '2'
 WORKERS_AUTO = 'auto'
 
-# To reduce number of test cases, we exclude WORKERS_AUTO
-workers_options = [WORKERS_1, WORKERS_2]
+workers_options = None
+
+def select_workers_options(reduced : bool) -> None:
+    global workers_options
+    if reduced:
+        # To reduce number of test cases, we exclude WORKERS_AUTO
+        workers_options = [WORKERS_1, WORKERS_2]
+    else:
+        workers_options = [WORKERS_1, WORKERS_2, WORKERS_AUTO]
 
 @dataclass
 class FeatureId:

--- a/testgen/spec.py
+++ b/testgen/spec.py
@@ -169,6 +169,7 @@ feature_ids = [
     ("TlcPermuteFun", 'Permutations(S)', TlcPermuteFunF()),
     ("TlcSortSeq", 'SortSeq(<<...>>, Op)', TlcSortSeqF()),
     ("TlcEval", 'TLCEval(expr)', TlcEvalF()),
+    ("TlcAssert", 'Assert(cond, msg). Note: We only validate that Assert is equivalent to TRUE if it does not fire (report false positives). If assertion fires, we treat it as a crash and do not guarantee anything.', TlcAssertF()),
     ("BagBagToSet", 'BagToSet(expr)', BagBagToSetF()),
     ("BagSetToBag", 'SetToBag(S)', BagSetToBagF()),
     ("BagBagIn", 'BagIn(e, B)', BagBagInF()),

--- a/testgen/symmetry.py
+++ b/testgen/symmetry.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,7 @@
 from .ast import *
 from .testcase import *
 
-def etalon_cfg(deadlock, invariant = False, property = False):
-    inv = "INVARIANT Inv" if invariant else ""
-    prop = "PROPERTY Prop" if property else ""
-
+def etalon_cfg(deadlock, invariant, property, view):
     return fR"""
 \* CONFIG
 
@@ -34,41 +31,64 @@ CONSTANT
 SPECIFICATION
     Spec
 
-CHECK_DEADLOCK {'TRUE' if deadlock else 'FALSE'}
-
-{inv}
-{prop}
+{deadlock}
+{view or ''}
+{invariant or ''}
+{property or ''}
 """
 
 def symmetry_cases():
     name = 'SymmetrySpec'
-    view_line = "VIEW ViewDef"
-    symmetry = "SYMMETRY MessagesSymm"
-
+    symmetries = [
+        ("Permutations(U)", "SYMMETRY MessagesSymm1"),
+        (R"Permutations(U) \union Permutations(V)", "SYMMETRY MessagesSymm2"),
+    ]
+    invariants = [
+        ("Positive", "INVARIANT InvPos"),
+        ("Negative", "INVARIANT InvNeg"),
+        ("Absent", None),
+    ]
+    properties = [
+        ("Positive", "PROPERTY PropPos"),
+        ("Negative", "PROPERTY PropNeg"),
+        ("Absent", None),
+    ]
+    views = [
+        (True, "VIEW ViewDef"),
+        (False, None),
+    ]
+    deadlocks = [
+        (True, "CHECK_DEADLOCK TRUE"),
+        (False, "CHECK_DEADLOCK FALSE"),
+    ]
     cases = []
 
-    for deadlock in [True, False]:
-        for inv in [True, False]:
-            for property in [True, False]:
-                ref = etalon_cfg(deadlock = deadlock, invariant = inv, property = property)
-                ref_model = PlainFileModel(name, cfg_content = ref)
-                for view in [True, False]:
-                    parts = [ref, symmetry]
-                    if view:
-                        parts.append(view_line)
-                    tlc = '\n'.join(parts)
-                    tlc_model = PlainFileModel(name, cfg_content = tlc)
+    for symmetry in symmetries:
+        for invariant in invariants:
+            for property in properties:
+                for view in views:
+                    for deadlock in deadlocks:
+                        ref = etalon_cfg(
+                            deadlock = deadlock[1],
+                            invariant = invariant[1],
+                            property = property[1],
+                            view = view[1],
+                        )
+                        ref_model = PlainFileModel(name, cfg_content = ref)
+                        tlc = '\n'.join([ref, symmetry[1]])
+                        tlc_model = PlainFileModel(name, cfg_content = tlc)
 
-                    desc = {
-                        'check_deadlock' : deadlock,
-                        'invariant' : inv,
-                        'property' : property,
-                        'view' : view,
-                        'reduction_strategy': {
-                            'configuration': 'Do not use SYMMETRY optimization'
+                        desc = {
+                            'check_deadlock' : deadlock[0],
+                            'invariant' : invariant[0],
+                            'property' : property[0],
+                            'view' : view[0],
+                            'symmetry' : symmetry[0],
+                            'reduction_strategy': {
+                                'configuration': 'Do not use SYMMETRY optimization'
+                            },
                         }
-                    }
 
-                    case = TlcSymmetryCase(tlc_model, ref_model, desc)
-                    cases.append(case)
+                        case = TlcSymmetryCase(tlc_model, ref_model, desc)
+                        cases.append(case)
     return cases

--- a/testgen/symmetry.py
+++ b/testgen/symmetry.py
@@ -40,8 +40,8 @@ SPECIFICATION
 def symmetry_cases():
     name = 'SymmetrySpec'
     symmetries = [
-        ("Permutations(U)", "SYMMETRY MessagesSymm1"),
-        (R"Permutations(U) \union Permutations(V)", "SYMMETRY MessagesSymm2"),
+        ("Permutations(U), where U is a symmetrical set of model values", "SYMMETRY MessagesSymm1"),
+        (R"Permutations(U) \union Permutations(V), where U and V are symmetrical sets of model values", "SYMMETRY MessagesSymm2"),
     ]
     invariants = [
         ("Positive", "INVARIANT InvPos"),

--- a/testgen/templates/test-symmetry.html
+++ b/testgen/templates/test-symmetry.html
@@ -47,6 +47,9 @@ optimization.
       Type
     </th>
     <th>
+      Symmetry Variant
+    </th>
+    <th>
       Check Deadlock
     </th>
     <th>
@@ -81,6 +84,9 @@ optimization.
             {% else %}
               Apalache
             {% endif %}
+          </td>
+          <td>
+            <span class="keyword">{{ tc.desc.symmetry }}</span>
           </td>
           <td>
             <span class="keyword">{{ tc.desc.check_deadlock }}</span>

--- a/testgen/testcase.py
+++ b/testgen/testcase.py
@@ -528,7 +528,7 @@ class TlcSymmetryCase(RefTlcCase):
                 return [prefix + '_neg']
             else:
                 return []
-        symm = ['symm1'] if self.desc['symmetry'] == 'Permutations(U)' else ['symm2']
+        symm = ['symm1'] if R'\union' not in self.desc['symmetry'] else ['symm2']
         inv = inv_prop('i', self.desc['invariant'])
         prop = inv_prop('p', self.desc['property'])
         view = ['v'] if self.desc['view'] else []

--- a/testgen/testcase.py
+++ b/testgen/testcase.py
@@ -521,12 +521,20 @@ class TlcSymmetryCase(RefTlcCase):
         super().__init__(tlc, ref, desc)
 
     def make_path(self, parent_dir):
-        inv = ['i'] if self.desc['invariant'] else []
-        prop = ['p'] if self.desc['property'] else []
+        def inv_prop(prefix, value):
+            if value == 'Positive':
+                return [prefix + '_pos']
+            elif value == 'Negative':
+                return [prefix + '_neg']
+            else:
+                return []
+        symm = ['symm1'] if self.desc['symmetry'] == 'Permutations(U)' else ['symm2']
+        inv = inv_prop('i', self.desc['invariant'])
+        prop = inv_prop('p', self.desc['property'])
         view = ['v'] if self.desc['view'] else []
         dl = ['dl'] if self.desc['check_deadlock'] else []
 
-        path = '-'.join(['symmetry'] + inv + prop + view + dl)
+        path = '-'.join(['symmetry'] + symm + inv + prop + view + dl)
 
         tlc_path = os.path.join(path, 'tlc')
         ref_path = os.path.join(path, 'ref')

--- a/testgen/testcasedefs.py
+++ b/testgen/testcasedefs.py
@@ -36,7 +36,7 @@ class AnomalousCondition(Enum):
         if self == AnomalousCondition.OutOfMemory:
             desc = {
                 'desc' : 'Out of memory',
-                'memory' : 5000000
+                'memory' : 500000
             }
         elif self == AnomalousCondition.OutOfSpace:
             desc = {

--- a/tools/2026.04.27.203507/tla2tools.jar
+++ b/tools/2026.04.27.203507/tla2tools.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:accf1505b3a27679b532753e0430dbea1673c9935d7991dc2536b99ce69976fa
+size 4356776

--- a/tools/Apalache-0.57.0-LICENSE
+++ b/tools/Apalache-0.57.0-LICENSE
@@ -1,0 +1,219 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   This software has been developed by the following core contributors:
+    
+     * Igor Konnov:
+        - Informal Systems (Austria) 2020-2023,
+        - Interchain Foundation (Switzerland) 2019,
+        - INRIA Nancy (France) 2018-2019,
+        - TU Wien (Austria) 2016-2018.
+     * Jure Kukovec:
+        - Informal Systems (Austria) 2021-2023,
+        - TU Wien (Austria), 2016-2021.
+     * Shon Feder: Informal Systems (Canada), 2020-2023.
+     * Gabriela Moreira: Informal Systems (Brazil), 2021-2023.
+     * Thomas Pani: Informal Systems (Austria), 2022-2023.
+     * Rodrigo Otoni:
+       USI Università della Svizzera italiana (Switzerland), 2021-2022.
+     * Philip Offtermatt: Informal Systems, 2022.
+     * Andrey Kuprianov: Informal Systems (Austria) 2020.
+     * Thanh Hai Tran: TU Wien (Austria), 2016-2020.
+     * Viktor Sergeev: Univ. of Lorraine (France), 2019.
+
+   Further, we appreciate code and documentation contributions by:
+
+     * @BGR360 Ben Reeves, 2022-2023.
+     * @Alexander-N Alexander Niederbühl, 2021.
+     * @rnbguy Rano, 2021-2022.
+     * @klinvill Kirby Linvill, 2021.
+     * @JonathanLorimer Jonathan Lorimer, 2021.
+     * @danwt Daniel T, 2021.
+     * @jlu015 Jørgen Lund, 2019.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/tools/apalache-0.57.0.jar
+++ b/tools/apalache-0.57.0.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c2500ec2b014fcf41a7b0bd4c30fc3204b69377028fd689224eea9cf23f66f5
+size 136005985

--- a/tools/run_suite.sh
+++ b/tools/run_suite.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,4 @@ set -eo pipefail
 readonly PROJECT_DIR=$( readlink -f `dirname $0`/.. )
 readonly CPUS=$( nproc )
 readonly REPORT_DIR=${PROJECT_DIR}/mount/tqr
-python -m testgen -o ${REPORT_DIR} -s -e --html -x ${PROJECT_DIR}/explanation.yaml -w ${CPUS} --report-unused-explanations $*
+python -m testgen -o ${REPORT_DIR} -s -e --html -x ${PROJECT_DIR}/explanation.yaml -w ${CPUS} --report-unused-explanations "$@"

--- a/tools/run_suite.sh
+++ b/tools/run_suite.sh
@@ -19,4 +19,4 @@ set -eo pipefail
 readonly PROJECT_DIR=$( readlink -f `dirname $0`/.. )
 readonly CPUS=$( nproc )
 readonly REPORT_DIR=${PROJECT_DIR}/mount/tqr
-python -m testgen -o ${REPORT_DIR} -s -e --html -x ${PROJECT_DIR}/explanation.yaml -w ${CPUS} $*
+python -m testgen -o ${REPORT_DIR} -s -e --html -x ${PROJECT_DIR}/explanation.yaml -w ${CPUS} --report-unused-explanations $*


### PR DESCRIPTION
- Update explanations for properties specified by operators
- Upgrade default apalache version to 0.57.0
- Extend symmetry test cases
- Report existing but unused explanations
- Scope --reduced-workers to specification stage
- Add Assert feature
- Align with the safety manual:
    Switch TLC default version to 2026.04.27.203507
    Add "-messagesAsErrors" with the list of dagerous warnings.
    Add "-fp" with random polynomial to facilitate independence of mutliple runs.
    Remove code that looked for warnings in the TLC output (replaced with "-messagesAsErrors).
- Add a new TLA+ tools JAR
- Make list of "-workers" options configurable